### PR TITLE
Add routes for cohort page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,7 +25,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>100DevsTracker</title>
 
     <!-- google font -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,8 @@ import StudentClassTracker from './pages/Student/StudentClassTracker';
 import AdminMainLayout from './pages/Admin/AdminMainLayout';
 import AdminDashboard from './pages/Admin/AdminDashboard';
 import AdminUpdateClass from './pages/Admin/AdminUpdateClass';
+import AdminCohortPage from './pages/Admin/AdminCohortPage';
+import StudentCohortPage from './pages/Student/StudentCohortPage';
 
 const App = () => {
   return (
@@ -25,15 +27,27 @@ const App = () => {
         <Route path="sign-in" element={<SignIn />} />
         <Route path="forgot-password" element={<ForgotPassword />} />
         <Route path="create-password" element={<CreatePassword />} />
-        <Route path="admin" element={<AdminMainLayout />}>
-          <Route path="home" element={<AdminDashboard />} />
-          <Route path="class" element={<AdminUpdateClass />} />
-          <Route index element={<Navigate to="/admin/home" replace />} />
+        <Route path="admin">
+          <Route path="cohort" element={<AdminMainLayout />}>
+            <Route index element={<AdminCohortPage />} />
+            <Route path=":id">
+              <Route path="home" element={<AdminDashboard />} />
+              <Route path="class" element={<AdminUpdateClass />} />
+              <Route index element={<Navigate to="home" replace />} />
+            </Route>
+          </Route>
+          <Route index element={<Navigate to="cohort" replace />} />
         </Route>
-        <Route path="student" element={<StudentMainLayout />}>
-          <Route path="home" element={<StudentDashboard />} />
-          <Route path="class" element={<StudentClassTracker />} />
-          <Route index element={<Navigate to="/student/home" replace />} />
+        <Route path="student">
+          <Route path="cohort" element={<StudentMainLayout />}>
+            <Route index element={<StudentCohortPage />} />
+            <Route path=":id">
+              <Route path="home" element={<StudentDashboard />} />
+              <Route path="class" element={<StudentClassTracker />} />
+              <Route index element={<Navigate to="home" replace />} />
+            </Route>
+          </Route>
+          <Route index element={<Navigate to="cohort" replace />} />
         </Route>
       </Routes>
     </ThemeProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,9 +31,9 @@ const App = () => {
           <Route path="cohort" element={<AdminMainLayout />}>
             <Route index element={<AdminCohortPage />} />
             <Route path=":id">
-              <Route path="home" element={<AdminDashboard />} />
+              <Route path="dashboard" element={<AdminDashboard />} />
               <Route path="class" element={<AdminUpdateClass />} />
-              <Route index element={<Navigate to="home" replace />} />
+              <Route index element={<Navigate to="dashboard" replace />} />
             </Route>
           </Route>
           <Route index element={<Navigate to="cohort" replace />} />
@@ -42,9 +42,9 @@ const App = () => {
           <Route path="cohort" element={<StudentMainLayout />}>
             <Route index element={<StudentCohortPage />} />
             <Route path=":id">
-              <Route path="home" element={<StudentDashboard />} />
+              <Route path="dashboard" element={<StudentDashboard />} />
               <Route path="class" element={<StudentClassTracker />} />
-              <Route index element={<Navigate to="home" replace />} />
+              <Route index element={<Navigate to="dashboard" replace />} />
             </Route>
           </Route>
           <Route index element={<Navigate to="cohort" replace />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,7 +28,7 @@ const App = () => {
         <Route path="forgot-password" element={<ForgotPassword />} />
         <Route path="create-password" element={<CreatePassword />} />
         <Route path="admin">
-          <Route path="cohort" element={<AdminMainLayout />}>
+          <Route path="cohorts" element={<AdminMainLayout />}>
             <Route index element={<AdminCohortPage />} />
             <Route path=":id">
               <Route path="dashboard" element={<AdminDashboard />} />
@@ -39,7 +39,7 @@ const App = () => {
           <Route index element={<Navigate to="cohort" replace />} />
         </Route>
         <Route path="student">
-          <Route path="cohort" element={<StudentMainLayout />}>
+          <Route path="cohorts" element={<StudentMainLayout />}>
             <Route index element={<StudentCohortPage />} />
             <Route path=":id">
               <Route path="dashboard" element={<StudentDashboard />} />

--- a/src/pages/Admin/AdminCohortPage.tsx
+++ b/src/pages/Admin/AdminCohortPage.tsx
@@ -6,7 +6,7 @@ const AdminCohortPage = () => {
   return (
     <div>
       <div>Admin Cohort Page</div>
-      <Link to={`/admin/cohort/${id}`}>Cohort id {id}</Link>
+      <Link to={`/admin/cohorts/${id}`}>Cohort id {id}</Link>
     </div>
   );
 };

--- a/src/pages/Admin/AdminCohortPage.tsx
+++ b/src/pages/Admin/AdminCohortPage.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const AdminCohortPage = () => {
+  const id = '1';
+  return (
+    <div>
+      <div>Admin Cohort Page</div>
+      <Link to={`/admin/cohort/${id}`}>Cohort id {id}</Link>
+    </div>
+  );
+};
+
+export default AdminCohortPage;

--- a/src/pages/Admin/AdminNavbar.tsx
+++ b/src/pages/Admin/AdminNavbar.tsx
@@ -5,7 +5,7 @@ import Navbar from '../../components/Navbar/Navbar';
 
 const AdminNavbar = () => {
   const isCohortPage = useMatch({
-    path: '/admin/cohort',
+    path: '/admin/cohorts',
     end: true,
     caseSensitive: false,
   });
@@ -15,9 +15,9 @@ const AdminNavbar = () => {
     <Navbar>
       {!isCohortPage && (
         <>
-          <MenuItem to="/admin/cohort/">Cohort List</MenuItem>
-          <MenuItem to={`/admin/cohort/${id}/dashboard`}>Dashboard</MenuItem>
-          <MenuItem to={`/admin/cohort/${id}/class`}>Update Class</MenuItem>
+          <MenuItem to="/admin/cohorts/">Cohort List</MenuItem>
+          <MenuItem to={`/admin/cohorts/${id}/dashboard`}>Dashboard</MenuItem>
+          <MenuItem to={`/admin/cohorts/${id}/class`}>Update Class</MenuItem>
         </>
       )}
       <div>Logout</div>

--- a/src/pages/Admin/AdminNavbar.tsx
+++ b/src/pages/Admin/AdminNavbar.tsx
@@ -15,7 +15,8 @@ const AdminNavbar = () => {
     <Navbar>
       {!isCohortPage && (
         <>
-          <MenuItem to={`/admin/cohort/${id}/home`}>Dashboard</MenuItem>
+          <MenuItem to="/admin/cohort/">Cohort List</MenuItem>
+          <MenuItem to={`/admin/cohort/${id}/dashboard`}>Dashboard</MenuItem>
           <MenuItem to={`/admin/cohort/${id}/class`}>Update Class</MenuItem>
         </>
       )}

--- a/src/pages/Admin/AdminNavbar.tsx
+++ b/src/pages/Admin/AdminNavbar.tsx
@@ -1,12 +1,24 @@
 import React from 'react';
+import { useMatch, useParams } from 'react-router-dom';
 import MenuItem from '../../components/Navbar/MenuItem';
 import Navbar from '../../components/Navbar/Navbar';
 
 const AdminNavbar = () => {
+  const isCohortPage = useMatch({
+    path: '/admin/cohort',
+    end: true,
+    caseSensitive: false,
+  });
+  const { id } = useParams();
+
   return (
     <Navbar>
-      <MenuItem to="/admin/home">Dashboard</MenuItem>
-      <MenuItem to="/admin/class">Update Class</MenuItem>
+      {!isCohortPage && (
+        <>
+          <MenuItem to={`/admin/cohort/${id}/home`}>Dashboard</MenuItem>
+          <MenuItem to={`/admin/cohort/${id}/class`}>Update Class</MenuItem>
+        </>
+      )}
       <div>Logout</div>
     </Navbar>
   );

--- a/src/pages/Student/StudentCohortPage.tsx
+++ b/src/pages/Student/StudentCohortPage.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const StudentCohortPage = () => {
+  const id = '1';
+  return (
+    <div>
+      <div>Student Cohort Page</div>
+      <Link to={`/student/cohort/${id}`}>Cohort id {id}</Link>
+    </div>
+  );
+};
+
+export default StudentCohortPage;

--- a/src/pages/Student/StudentCohortPage.tsx
+++ b/src/pages/Student/StudentCohortPage.tsx
@@ -6,7 +6,7 @@ const StudentCohortPage = () => {
   return (
     <div>
       <div>Student Cohort Page</div>
-      <Link to={`/student/cohort/${id}`}>Cohort id {id}</Link>
+      <Link to={`/student/cohorts/${id}`}>Cohort id {id}</Link>
     </div>
   );
 };

--- a/src/pages/Student/StudentNavbar.tsx
+++ b/src/pages/Student/StudentNavbar.tsx
@@ -15,7 +15,8 @@ const StudentNavbar = () => {
     <Navbar>
       {!isCohortPage && (
         <>
-          <MenuItem to={`/student/cohort/${id}/home`}>Dashboard</MenuItem>
+          <MenuItem to="/student/cohort/">Cohort List</MenuItem>
+          <MenuItem to={`/student/cohort/${id}/dashboard`}>Dashboard</MenuItem>
           <MenuItem to={`/student/cohort/${id}/class`}>Class Tracker</MenuItem>
         </>
       )}

--- a/src/pages/Student/StudentNavbar.tsx
+++ b/src/pages/Student/StudentNavbar.tsx
@@ -5,7 +5,7 @@ import Navbar from '../../components/Navbar/Navbar';
 
 const StudentNavbar = () => {
   const isCohortPage = useMatch({
-    path: '/student/cohort',
+    path: '/student/cohorts',
     end: true,
     caseSensitive: false,
   });
@@ -15,9 +15,9 @@ const StudentNavbar = () => {
     <Navbar>
       {!isCohortPage && (
         <>
-          <MenuItem to="/student/cohort/">Cohort List</MenuItem>
-          <MenuItem to={`/student/cohort/${id}/dashboard`}>Dashboard</MenuItem>
-          <MenuItem to={`/student/cohort/${id}/class`}>Class Tracker</MenuItem>
+          <MenuItem to="/student/cohorts/">Cohort List</MenuItem>
+          <MenuItem to={`/student/cohorts/${id}/dashboard`}>Dashboard</MenuItem>
+          <MenuItem to={`/student/cohorts/${id}/class`}>Class Tracker</MenuItem>
         </>
       )}
       <div>Logout</div>

--- a/src/pages/Student/StudentNavbar.tsx
+++ b/src/pages/Student/StudentNavbar.tsx
@@ -1,12 +1,24 @@
 import React from 'react';
+import { useParams, useMatch } from 'react-router-dom';
 import MenuItem from '../../components/Navbar/MenuItem';
 import Navbar from '../../components/Navbar/Navbar';
 
 const StudentNavbar = () => {
+  const isCohortPage = useMatch({
+    path: '/student/cohort',
+    end: true,
+    caseSensitive: false,
+  });
+  const { id } = useParams();
+
   return (
     <Navbar>
-      <MenuItem to="/student/home">Dashboard</MenuItem>
-      <MenuItem to="/student/class">Class Tracker</MenuItem>
+      {!isCohortPage && (
+        <>
+          <MenuItem to={`/student/cohort/${id}/home`}>Dashboard</MenuItem>
+          <MenuItem to={`/student/cohort/${id}/class`}>Class Tracker</MenuItem>
+        </>
+      )}
       <div>Logout</div>
     </Navbar>
   );


### PR DESCRIPTION
Closes #53 

This PR adds another route layer for `cohort`. So the previously added routes will be nested under `/cohorts/:id`

https://user-images.githubusercontent.com/40800353/167527336-693c6faa-2564-4a3f-9b88-45807943eeb9.mp4


Added cohort to navbar:
<img width="406" alt="Screen Shot 2022-05-10 at 9 10 34 PM" src="https://user-images.githubusercontent.com/40800353/167749121-19241ca1-8e05-4c19-83f2-ed6c3466fe1c.png">

