### PR TITLE
Edit class styling

### DIFF
--- a/src/api/classes.tsx
+++ b/src/api/classes.tsx
@@ -10,6 +10,7 @@ export interface CreateClassProps {
 export interface CreateClassWorkProps {
   name: string;
   description: string;
+  type?: string;
 }
 
 // Class Apis

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from "styled-components";
 
 export const Button = styled.button`
   display: flex;

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -59,10 +59,7 @@ export const InvertPrimaryButton = styled(Button)`
     color: ${({ theme }) => theme.color.white};
     cursor: pointer;
   }
-
-
-  
-`
+`;
 
 export const LeftArrowButton = styled.button`
   height: 21px;
@@ -80,5 +77,3 @@ export const LeftArrowButton = styled.button`
     text-decoration: underline;
   }
 `;
-
-;

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -59,4 +59,26 @@ export const InvertPrimaryButton = styled(Button)`
     color: ${({ theme }) => theme.color.white};
     cursor: pointer;
   }
+
+
+  
+`
+
+export const LeftArrowButton = styled.button`
+  height: 21px;
+  font-weight: 400;
+  font-size: 16px;
+  letter-spacing: 0.5px;
+  margin: 2% 5% 2% 5%;
+  background-color: transparent;
+  color: ${({ theme }) => theme.color.primary};
+  padding: 0;
+  border: none;
+  &:hover {
+    font-weight: bold;
+    cursor: pointer;
+    text-decoration: underline;
+  }
 `;
+
+;

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from "styled-components";
 
 export const Form = styled.form`
   display: flex;

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -3,12 +3,11 @@ import { InputFieldProps } from 'types';
 
 export const Input = styled.input<InputFieldProps>`
   background: none;
-  border: 1px solid ${({ theme }) => theme.color.black};
+  border: 1px solid ${({ theme }) => theme.color.grey};
   border-color: ${({ hasError, theme }) => hasError && theme.color.red};
-  border-radius: 4px;
   min-height: 40px;
   width: 11rem;
-  color: ${({ theme }) => theme.color.black};
+  color: ${({ theme }) => theme.color.darkGrey};
   font-weight: 300;
   padding-left: 8px;
 
@@ -21,16 +20,24 @@ export const InputField = styled.label`
   display: flex;
   gap: 0.5em;
   flex-direction: column;
+  span {
+    padding-top: 5px;
+    font-style: normal;
+    font-weight: 400;
+    font-size: 14px;
+    line-height: 24px;
+    letter-spacing: 0.5px;
+  }
 `;
 
 export const TextArea = styled.textarea<InputFieldProps>`
   background: none;
-  border: 1px solid ${({ theme }) => theme.color.black};
+  border: 1px solid ${({ theme }) => theme.color.grey};
   border-color: ${({ hasError, theme }) => hasError && theme.color.red};
   border-radius: 4px;
   min-height: 8rem;
   width: 11rem;
-  color: ${({ theme }) => theme.color.black};
+  color: ${({ theme }) => theme.color.darkGrey};
   font-weight: 300;
   padding-left: 8px;
   padding-top: 8px;

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -7,10 +7,13 @@ export const Input = styled.input<InputFieldProps>`
   border-color: ${({ hasError, theme }) => hasError && theme.color.red};
   min-height: 40px;
   width: 11rem;
-  color: ${({ theme }) => theme.color.darkGrey};
+  color: ${({ theme }) => theme.color.black};
   font-weight: 300;
   padding-left: 8px;
-
+  &::placeholder {
+    color: ${({ theme }) => theme.color.darkGrey};
+    opacity: 1;
+  }
   :focus {
     outline: none;
   }
@@ -48,12 +51,12 @@ export const Option = styled.option`
   display: flex;
   white-space: pre;
   background: ${({ theme }) => theme.color.white};
-  padding-top: 5px;
+  padding-top: 0.3em;
   font-style: normal;
   font-weight: 400;
-  font-size: 14px;
-  line-height: 24px;
-  letter-spacing: 0.5px;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+  letter-spacing: 0.031rem;
 `;
 
 export const TextArea = styled.textarea<InputFieldProps>`
@@ -63,11 +66,14 @@ export const TextArea = styled.textarea<InputFieldProps>`
   border-radius: 4px;
   min-height: 8rem;
   width: 11rem;
-  color: ${({ theme }) => theme.color.darkGrey};
+  color: ${({ theme }) => theme.color.black};
   font-weight: 300;
   padding-left: 8px;
   padding-top: 8px;
-
+  &::placeholder {
+    color: ${({ theme }) => theme.color.darkGrey};
+    opacity: 1;
+  }
   :focus {
     outline: none;
   }

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -30,6 +30,32 @@ export const InputField = styled.label`
   }
 `;
 
+export const Select = styled.select<InputFieldProps>`
+  position: relative;
+  background: transparent;
+  border: 1px solid ${({ theme }) => theme.color.grey};
+  border-color: ${({ hasError, theme }) => hasError && theme.color.red};
+  min-height: 40px;
+  color: ${({ theme }) => theme.color.darkGrey};
+  font-weight: 300;
+  padding-left: 8px;
+  :focus {
+    outline: none;
+  }
+`;
+export const Option = styled.option`
+  color: ${({ theme }) => theme.color.black};
+  display: flex;
+  white-space: pre;
+  background: ${({ theme }) => theme.color.white};
+  padding-top: 5px;
+  font-style: normal;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 24px;
+  letter-spacing: 0.5px;
+`;
+
 export const TextArea = styled.textarea<InputFieldProps>`
   background: none;
   border: 1px solid ${({ theme }) => theme.color.grey};

--- a/src/pages/Editor/Classes/ClassComponent.styled.tsx
+++ b/src/pages/Editor/Classes/ClassComponent.styled.tsx
@@ -85,7 +85,7 @@ export const EditClassContentIcon = styled(AiOutlineEdit)`
 export const TrashIcon = styled(BiTrashAlt)`
   ${iconStyles}
   color: ${({ theme }) => theme.color.black};
-  font-size: 21px;
+  font-size: 1.313rem;
 `;
 
 export const AddClassContentIcon = styled(MdAdd)`
@@ -96,7 +96,7 @@ export const AddClassContentIcon = styled(MdAdd)`
 export const LeftArrow = styled(FaArrowLeft)`
   ${iconStyles}
   color: ${({ theme }) => theme.color.primary};
-  font-size: 15px;
+  font-size: 0.938rem;
 `;
 export const MaterialLists = styled.div`
   margin: 2rem;

--- a/src/pages/Editor/Classes/ClassComponent.styled.tsx
+++ b/src/pages/Editor/Classes/ClassComponent.styled.tsx
@@ -1,8 +1,9 @@
 import styled from 'styled-components';
 import { AiOutlineEdit, AiOutlineAppstoreAdd } from 'react-icons/ai';
-import { BiTrash, BiPencil } from 'react-icons/bi';
+import { BiPencil, BiTrashAlt } from 'react-icons/bi';
 import { MdAdd } from 'react-icons/md';
 import { iconStyles } from 'pages/Editor/Classes/styles';
+import { FaArrowLeft } from 'react-icons/fa';
 
 export const StyledClassContainer = styled.section`
   display: flex;
@@ -81,9 +82,10 @@ export const EditClassContentIcon = styled(AiOutlineEdit)`
   color: ${({ theme }) => theme.color.white};
 `;
 
-export const TrashIcon = styled(BiTrash)`
+export const TrashIcon = styled(BiTrashAlt)`
   ${iconStyles}
-  color: ${({ theme }) => theme.color.red};
+  color: ${({ theme }) => theme.color.black};
+  font-size: 21px;
 `;
 
 export const AddClassContentIcon = styled(MdAdd)`
@@ -91,6 +93,11 @@ export const AddClassContentIcon = styled(MdAdd)`
   color: ${({ theme }) => theme.color.primary};
 `;
 
+export const LeftArrow = styled(FaArrowLeft)`
+  ${iconStyles}
+  color: ${({ theme }) => theme.color.primary};
+  font-size: 15px;
+`;
 export const MaterialLists = styled.div`
   margin: 2rem;
   width: 15rem;

--- a/src/pages/Editor/Classes/ClassComponent.tsx
+++ b/src/pages/Editor/Classes/ClassComponent.tsx
@@ -14,7 +14,7 @@ import {
   ClassComponentDataProps,
   classesProps,
   headerProps,
-  classesWorkProps,
+  classWorkProps,
 } from 'pages/Editor/Classes/classTypes';
 
 /* eslint no-underscore-dangle: 0 */
@@ -24,10 +24,12 @@ const getHeaderComponent = ({ item, fetchClasses }: headerProps) => {
 };
 
 const ClassComponent = ({ classes = [], fetchClasses }: classesProps) => {
-  const classWorkDetails = (innerElement: classesWorkProps) => {
+  const classWorkDetails = (innerElement: classWorkProps) => {
     if (innerElement.description) {
       return (
         <>
+          <ClassworkIcon /> {innerElement.type}
+          <ClassworkIcon /> {innerElement.name}
           <ClassworkIcon /> {innerElement.description}
         </>
       );

--- a/src/pages/Editor/Classes/UpdateClassModals/EditClassModal.tsx
+++ b/src/pages/Editor/Classes/UpdateClassModals/EditClassModal.tsx
@@ -12,7 +12,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { StyledErrorMessage } from 'components/ErrorMessage';
 
 import { Modal } from 'components/Modal/Modal';
-import { PrimaryButton } from 'components/Button';
+import { PrimaryButton, LeftArrowButton } from 'components/Button';
 import {
   classValidationRules,
   classWorkValidationRules,
@@ -23,57 +23,8 @@ import {
   TrashIcon,
 } from 'pages/Editor/Classes/ClassComponent.styled';
 
-const StyledForm = styled.form`
-  margin: 0 5% 0 5%;
-  font-family: 'Poppins';
-  font-style: normal;
-  display: flex;
-  flex-direction: column;
-  gap: 1em;
-`;
+import { StyledForm, Classworks, ClassWorkHeading, AddNewClassWorkBtn } from 'pages/Editor/Classes/styles'
 
-const Classworks = styled.div`
-  display: flex;
-  flex-direction: column;
-`;
-
-const ClassWorkHeading = styled.div`
-  height: 50px;
-  background: ${({ theme }) => theme.color.secondary};
-  display: flex;
-  justify-content: space-between;
-  margin: 2px 0 2px 0;
-  padding: 10px;
-
-  span {
-    height: 30px;
-    font-weight: 600;
-    font-size: 16px;
-    line-height: 30px;
-    letter-spacing: 0.5px;
-  }
-`;
-const AddNewClassWorkBtn = styled(PrimaryButton)`
-  border-radius: 20px;
-  position: absolute;
-  left: 7%;
-`;
-const ReturnBtn = styled.button`
-  height: 21px;
-  font-weight: 400;
-  font-size: 16px;
-  letter-spacing: 0.5px;
-  margin: 2% 5% 2% 5%;
-  background-color: transparent;
-  color: ${({ theme }) => theme.color.primary};
-  padding: 0;
-  border: none;
-  &:hover {
-    font-weight: bold;
-    cursor: pointer;
-    text-decoration: underline;
-  }
-`;
 
 /* eslint no-underscore-dangle: 0 */
 
@@ -151,9 +102,9 @@ export const EditClassModal = ({
         },
       }}
     >
-      <ReturnBtn>
+      <LeftArrowButton onClick={handleCancelModal}>
         <LeftArrow /> back to Syllabus
-      </ReturnBtn>
+      </LeftArrowButton>
       <StyledForm id="EditClassForm" onSubmit={handleSubmit(onSubmit)}>
         <InputField htmlFor="name">
           <span>Class Title</span>

--- a/src/pages/Editor/Classes/UpdateClassModals/EditClassModal.tsx
+++ b/src/pages/Editor/Classes/UpdateClassModals/EditClassModal.tsx
@@ -18,21 +18,55 @@ import {
   classWorkValidationRules,
 } from 'utilities/validation';
 import { FaPlus } from 'react-icons/fa';
-import { TrashIcon } from 'pages/Editor/Classes/ClassComponent.styled';
+import {
+  LeftArrow,
+  TrashIcon,
+} from 'pages/Editor/Classes/ClassComponent.styled';
 
 const StyledForm = styled.form`
+  margin: 0 5% 0 5%;
+  font-family: 'Poppins';
+  font-style: normal;
   display: flex;
   flex-direction: column;
   gap: 1em;
 `;
 
 const Classworks = styled.div`
-  background: #fff;
-  border-radius: 4px;
-  padding: 1em;
-  overflow: hidden;
-  box-shadow: 0 13px 27px -5px hsla(240, 30.1%, 28%, 0.25),
-    0 8px 1px -8px hsla(0, 0%, 0%, 0.1), 0 -6px 16px -6px hsla(0, 0%, 0%, 0.03);
+  display: flex;
+  flex-direction: column;
+`;
+
+const ClassWorkHeading = styled.div`
+  height: 50px;
+  background: ${({ theme }) => theme.color.secondary};
+  display: flex;
+  justify-content: space-between;
+  margin: 2px 0 2px 0;
+  padding: 10px;
+
+  span {
+    height: 30px;
+    font-weight: 600;
+    font-size: 16px;
+    line-height: 30px;
+    letter-spacing: 0.5px;
+  }
+`;
+const AddNewClassWorkBtn = styled(PrimaryButton)`
+  border-radius: 20px;
+`;
+const ReturnBtn = styled(Button)`
+  border-radius: 20px;
+  height: 21px;
+  font-weight: 400;
+  font-size: 14px;
+  letter-spacing: 0.5px;
+  margin: 2% 5% 2% 5%;
+  &:hover {
+    text-decoration: underline;
+    cursor: pointer;
+  }
 `;
 
 /* eslint no-underscore-dangle: 0 */
@@ -83,7 +117,7 @@ export const EditClassModal = ({
 
   return (
     <Modal
-      titleText="Edit Class"
+      titleText=""
       isOpen={isOpen}
       onCloseModal={toggle}
       primaryAction={
@@ -91,14 +125,29 @@ export const EditClassModal = ({
           Submit
         </PrimaryButton>
       }
-      secondaryAction={<Button onClick={handleCancelModal}>Cancel</Button>}
+      secondaryAction={
+        <AddNewClassWorkBtn
+          type="button"
+          onClick={() =>
+            append({
+              name: '',
+              description: '',
+            })
+          }
+        >
+          <FaPlus /> New Class Work
+        </AddNewClassWorkBtn>
+      }
       customStyles={{
         content: {
-          height: '90vh',
-          width: '90vw',
+          height: '100vh',
+          width: '100vw',
         },
       }}
     >
+      <ReturnBtn>
+        <LeftArrow /> back to Syllabus
+      </ReturnBtn>
       <StyledForm id="EditClassForm" onSubmit={handleSubmit(onSubmit)}>
         <InputField htmlFor="name">
           <span>Class Title</span>
@@ -130,8 +179,12 @@ export const EditClassModal = ({
           return (
             <div>
               <Classworks key={field.id}>
-                <InputField htmlFor="classworkName">
+                <ClassWorkHeading>
                   <span>Class Work {index + 1}</span>
+                  <TrashIcon type="button" onClick={() => remove(index)} />
+                </ClassWorkHeading>
+                <InputField htmlFor="classworkName">
+                  <span> Title</span>
                   <Input
                     placeholder="name"
                     {...register(
@@ -149,6 +202,7 @@ export const EditClassModal = ({
                   ) : null
                 )}
                 <InputField htmlFor="classworkDescription">
+                  <span> Description</span>
                   <Input
                     placeholder="description"
                     {...register(
@@ -165,22 +219,12 @@ export const EditClassModal = ({
                     </StyledErrorMessage>
                   ) : null
                 )}
-                <TrashIcon type="button" onClick={() => remove(index)} />
               </Classworks>
             </div>
           );
         })}
-        <PrimaryButton
-          onClick={() =>
-            append({
-              name: '',
-              description: '',
-            })
-          }
-        >
-          <FaPlus /> New Class Work
-        </PrimaryButton>
       </StyledForm>
+
       {errorMessages?.map(({ msg }) => (
         <StyledErrorMessage key={msg}>{msg}</StyledErrorMessage>
       ))}

--- a/src/pages/Editor/Classes/UpdateClassModals/EditClassModal.tsx
+++ b/src/pages/Editor/Classes/UpdateClassModals/EditClassModal.tsx
@@ -4,7 +4,7 @@
 import React, { useState } from 'react';
 import { useFieldArray, useForm } from 'react-hook-form';
 import styled from 'styled-components';
-import { Input, InputField, TextArea } from 'components/Input';
+import { Input, InputField, Select, TextArea, Option } from 'components/Input';
 import { ErrorMessageInterface } from 'types';
 import { EditClassModalProps } from 'pages/Editor/Classes/classTypes';
 import { CreateClassProps, editClass } from 'api/classes';
@@ -12,7 +12,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { StyledErrorMessage } from 'components/ErrorMessage';
 
 import { Modal } from 'components/Modal/Modal';
-import { Button, PrimaryButton } from 'components/Button';
+import { PrimaryButton } from 'components/Button';
 import {
   classValidationRules,
   classWorkValidationRules,
@@ -56,16 +56,19 @@ const ClassWorkHeading = styled.div`
 const AddNewClassWorkBtn = styled(PrimaryButton)`
   border-radius: 20px;
 `;
-const ReturnBtn = styled(Button)`
-  border-radius: 20px;
+const ReturnBtn = styled.button`
   height: 21px;
   font-weight: 400;
-  font-size: 14px;
+  font-size: 16px;
   letter-spacing: 0.5px;
-  margin: 2% 5% 2% 5%;
+  margin: 2% 5% 2% 2%;
+  background-color: transparent;
+  color: ${({ theme }) => theme.color.primary};
+  border: none;
   &:hover {
-    text-decoration: underline;
+    font-weight: bold;
     cursor: pointer;
+    text-decoration: underline;
   }
 `;
 
@@ -108,7 +111,7 @@ export const EditClassModal = ({
   const onSubmit = async (data: CreateClassProps) => {
     try {
       await editClass(data, item._id);
-      fetchClasses();
+      await fetchClasses();
       handleCancelModal();
     } catch (error) {
       setErrorMessages(error as ErrorMessageInterface[]);
@@ -154,25 +157,31 @@ export const EditClassModal = ({
           <Input
             type="text"
             id="name"
+            aria-invalid={errors.name ? 'true' : 'false'}
             placeholder="Enter Class Title"
             {...register('name', classValidationRules.name)}
             defaultValue={item.name}
           />
         </InputField>
         {errors.name?.message ? (
-          <StyledErrorMessage>{errors.name?.message}</StyledErrorMessage>
+          <StyledErrorMessage role="alert">
+            {errors.name?.message}
+          </StyledErrorMessage>
         ) : null}
         <InputField htmlFor="description">
           <span>Class Description</span>
           <TextArea
             id="description"
+            aria-invalid={errors.description ? 'true' : 'false'}
             placeholder="Enter Class description"
             {...register('description', classValidationRules.description)}
             defaultValue={item.description}
           />
         </InputField>
         {errors.description?.message ? (
-          <StyledErrorMessage>{errors.description?.message}</StyledErrorMessage>
+          <StyledErrorMessage role="alert">
+            {errors.description?.message}
+          </StyledErrorMessage>
         ) : null}
 
         {fields.map((field, index) => {
@@ -183,6 +192,30 @@ export const EditClassModal = ({
                   <span>Class Work {index + 1}</span>
                   <TrashIcon type="button" onClick={() => remove(index)} />
                 </ClassWorkHeading>
+                <InputField htmlFor="type">
+                  <span> Type</span>
+                  <Select
+                    id="type"
+                    placeholder="Select Type"
+                    {...register(
+                      `classworks.${index}.type` as const,
+                      classWorkValidationRules.type
+                    )}
+                    defaultValue={field.type}
+                  >
+                    <Option value="material" selected>
+                      Material
+                    </Option>
+                    <Option value="submission">Submission</Option>
+                  </Select>
+                </InputField>
+                {errors.classworks?.map(({ type }, ind) =>
+                  ind === index ? (
+                    <StyledErrorMessage role="alert" key={uuidv4()}>
+                      {type?.message}
+                    </StyledErrorMessage>
+                  ) : null
+                )}
                 <InputField htmlFor="classworkName">
                   <span> Title</span>
                   <Input
@@ -196,7 +229,7 @@ export const EditClassModal = ({
                 </InputField>
                 {errors.classworks?.map(({ name }, ind) =>
                   ind === index ? (
-                    <StyledErrorMessage key={uuidv4()}>
+                    <StyledErrorMessage role="alert" key={uuidv4()}>
                       {name?.message}
                     </StyledErrorMessage>
                   ) : null
@@ -214,7 +247,7 @@ export const EditClassModal = ({
                 </InputField>
                 {errors.classworks?.map(({ description }, ind) =>
                   ind === index ? (
-                    <StyledErrorMessage key={uuidv4()}>
+                    <StyledErrorMessage role="alert" key={uuidv4()}>
                       {description?.message}
                     </StyledErrorMessage>
                   ) : null

--- a/src/pages/Editor/Classes/UpdateClassModals/EditClassModal.tsx
+++ b/src/pages/Editor/Classes/UpdateClassModals/EditClassModal.tsx
@@ -1,30 +1,34 @@
 /* eslint-disable no-bitwise */
 /* eslint-disable jsx-a11y/label-has-associated-control */
 
-import React, { useState } from 'react';
-import { useFieldArray, useForm } from 'react-hook-form';
-import styled from 'styled-components';
-import { Input, InputField, Select, TextArea, Option } from 'components/Input';
-import { ErrorMessageInterface } from 'types';
-import { EditClassModalProps } from 'pages/Editor/Classes/classTypes';
-import { CreateClassProps, editClass } from 'api/classes';
-import { v4 as uuidv4 } from 'uuid';
-import { StyledErrorMessage } from 'components/ErrorMessage';
+import React, { useState } from "react";
+import { useFieldArray, useForm } from "react-hook-form";
+import styled from "styled-components";
+import { Input, InputField, Select, TextArea, Option } from "components/Input";
+import { ErrorMessageInterface } from "types";
+import { EditClassModalProps } from "pages/Editor/Classes/classTypes";
+import { CreateClassProps, editClass } from "api/classes";
+import { v4 as uuidv4 } from "uuid";
+import { StyledErrorMessage } from "components/ErrorMessage";
 
-import { Modal } from 'components/Modal/Modal';
-import { PrimaryButton, LeftArrowButton } from 'components/Button';
+import { Modal } from "components/Modal/Modal";
+import { PrimaryButton, LeftArrowButton } from "components/Button";
 import {
   classValidationRules,
   classWorkValidationRules,
-} from 'utilities/validation';
-import { FaPlus } from 'react-icons/fa';
+} from "utilities/validation";
+import { FaPlus } from "react-icons/fa";
 import {
   LeftArrow,
   TrashIcon,
-} from 'pages/Editor/Classes/ClassComponent.styled';
+} from "pages/Editor/Classes/ClassComponent.styled";
 
-import { StyledForm, Classworks, ClassWorkHeading, AddNewClassWorkBtn } from 'pages/Editor/Classes/styles'
-
+import {
+  StyledForm,
+  Classworks,
+  ClassWorkHeading,
+  AddNewClassWorkBtn,
+} from "pages/Editor/Classes/styles";
 
 /* eslint no-underscore-dangle: 0 */
 
@@ -44,10 +48,10 @@ export const EditClassModal = ({
     defaultValues: {
       classworks: item.classworks,
     },
-    mode: 'onChange',
+    mode: "onChange",
   });
   const { fields, append, remove } = useFieldArray({
-    name: 'classworks',
+    name: "classworks",
     control,
   });
 
@@ -87,8 +91,8 @@ export const EditClassModal = ({
           type="button"
           onClick={() =>
             append({
-              name: '',
-              description: '',
+              name: "",
+              description: "",
             })
           }
         >
@@ -97,8 +101,8 @@ export const EditClassModal = ({
       }
       customStyles={{
         content: {
-          height: '100vh',
-          width: '100vw',
+          height: "100vh",
+          width: "100vw",
         },
       }}
     >
@@ -111,9 +115,9 @@ export const EditClassModal = ({
           <Input
             type="text"
             id="name"
-            aria-invalid={errors.name ? 'true' : 'false'}
+            aria-invalid={errors.name ? "true" : "false"}
             placeholder="Enter Class Title"
-            {...register('name', classValidationRules.name)}
+            {...register("name", classValidationRules.name)}
             defaultValue={item.name}
           />
         </InputField>
@@ -126,9 +130,9 @@ export const EditClassModal = ({
           <span>Class Description</span>
           <TextArea
             id="description"
-            aria-invalid={errors.description ? 'true' : 'false'}
+            aria-invalid={errors.description ? "true" : "false"}
             placeholder="Enter Class description"
-            {...register('description', classValidationRules.description)}
+            {...register("description", classValidationRules.description)}
             defaultValue={item.description}
           />
         </InputField>

--- a/src/pages/Editor/Classes/UpdateClassModals/EditClassModal.tsx
+++ b/src/pages/Editor/Classes/UpdateClassModals/EditClassModal.tsx
@@ -55,15 +55,18 @@ const ClassWorkHeading = styled.div`
 `;
 const AddNewClassWorkBtn = styled(PrimaryButton)`
   border-radius: 20px;
+  position: absolute;
+  left: 7%;
 `;
 const ReturnBtn = styled.button`
   height: 21px;
   font-weight: 400;
   font-size: 16px;
   letter-spacing: 0.5px;
-  margin: 2% 5% 2% 2%;
+  margin: 2% 5% 2% 5%;
   background-color: transparent;
   color: ${({ theme }) => theme.color.primary};
+  padding: 0;
   border: none;
   &:hover {
     font-weight: bold;

--- a/src/pages/Editor/Classes/classTypes.tsx
+++ b/src/pages/Editor/Classes/classTypes.tsx
@@ -44,9 +44,13 @@ export interface headerProps {
   fetchClasses(): void;
 }
 
-export interface classesWorkProps {
+export interface classWorkProps {
   name: string;
   description: string;
+  classworkId?: string;
+  type?: string;
+  order?: string;
+  createdAt?: string;
 }
 
 export interface ClassHeaderDataProps {

--- a/src/pages/Editor/Classes/styles.tsx
+++ b/src/pages/Editor/Classes/styles.tsx
@@ -1,3 +1,4 @@
+import { PrimaryButton } from 'components/Button';
 import styled from 'styled-components';
 
 export const iconStyles = {
@@ -13,4 +14,40 @@ export const iconStyles = {
 export const StyledDateString = styled.span`
   font-weight: 100;
   font-style: italic;
+`;
+
+export const StyledForm = styled.form`
+  margin: 0 5% 0 5%;
+  font-family: 'Poppins';
+  font-style: normal;
+  display: flex;
+  flex-direction: column;
+  gap: 1em;
+`;
+
+export const Classworks = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const ClassWorkHeading = styled.div`
+  height: 50px;
+  background: ${({ theme }) => theme.color.secondary};
+  display: flex;
+  justify-content: space-between;
+  margin: 2px 0;
+  padding: 10px;
+
+  span {
+    height: 30px;
+    font-weight: 600;
+    font-size: 16px;
+    line-height: 30px;
+    letter-spacing: 0.5px;
+  }
+`;
+export const AddNewClassWorkBtn = styled(PrimaryButton)`
+  border-radius: 20px;
+  position: absolute;
+  left: 7%;
 `;

--- a/src/pages/Editor/Classes/styles.tsx
+++ b/src/pages/Editor/Classes/styles.tsx
@@ -41,13 +41,13 @@ export const ClassWorkHeading = styled.div`
   span {
     height: 30px;
     font-weight: 600;
-    font-size: 16px;
-    line-height: 30px;
-    letter-spacing: 0.5px;
+    font-size: 1rem;
+    line-height: 1.875rem;
+    letter-spacing: 0.031rem;
   }
 `;
 export const AddNewClassWorkBtn = styled(PrimaryButton)`
   border-radius: 20px;
   position: absolute;
-  left: 7%;
+  left: 15px;
 `;

--- a/src/pages/Editor/Classes/styles.tsx
+++ b/src/pages/Editor/Classes/styles.tsx
@@ -1,13 +1,14 @@
-import { PrimaryButton } from 'components/Button';
-import styled from 'styled-components';
+import { PrimaryButton } from "components/Button";
+import { Form } from "components/Form";
+import styled from "styled-components";
 
 export const iconStyles = {
-  fontSize: '1.3rem',
-  opacity: '80%',
-  cursor: 'pointer',
-  transition: 'all ease 0.1s',
-  '&:hover': {
-    opacity: '100%',
+  fontSize: "1.3rem",
+  opacity: "80%",
+  cursor: "pointer",
+  transition: "all ease 0.1s",
+  "&:hover": {
+    opacity: "100%",
   },
 };
 

--- a/src/utilities/validation.tsx
+++ b/src/utilities/validation.tsx
@@ -63,4 +63,7 @@ export const classWorkValidationRules = {
   description: {
     required: 'Class Work Description is required',
   },
+  type: {
+    required: 'Please select a valid Class Work type',
+  },
 };


### PR DESCRIPTION
This closes #121

This issue includes
* the styling update for Edit Class Modal
* ability to add classwork type
* minor refactoring 

Pending discussion: Styling for Drop down/ Select list for Class types as Select component can be used for tags as well (looking into [react-select](https://www.npmjs.com/package/react-select) component that can be reused for tags as well )  

![1EditClassModal](https://user-images.githubusercontent.com/35509459/183000362-cff58a92-dcb0-42ab-b567-ed79049d7f13.png)


 